### PR TITLE
Add API to rm paths/parents from a lot

### DIFF
--- a/src/lotman.cpp
+++ b/src/lotman.cpp
@@ -1,7 +1,6 @@
 #include <string.h>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json-schema.hpp>
-#include <iostream> // DELETE
 
 #include "lotman.h"
 #include "lotman_internal.h"
@@ -365,12 +364,12 @@ int lotman_update_lot(const char *lotman_JSON_str,
     }
 }
 
-int lotman_remove_from_lot(const char *lotman_JSON_str, char **err_msg) {
+int lotman_rm_parents_from_lot(const char *lotman_JSON_str, char **err_msg) {
     try {
          json subtraction_JSON_obj = json::parse(lotman_JSON_str);
         // Validate the incoming JSON
         json_validator validator;
-        validator.set_root_schema(lotman_schemas::lot_subtractions_schema);
+        validator.set_root_schema(lotman_schemas::lot_rm_parents_schema);
         validator.validate(subtraction_JSON_obj);
 
         // Check that lot exists
@@ -404,32 +403,16 @@ int lotman_remove_from_lot(const char *lotman_JSON_str, char **err_msg) {
             return -1; 
         }
 
-        // Start checking which keys to operate on
-        // Operate on parents key
-        if (subtraction_JSON_obj.contains("parents")) {
-            rp = lot.remove_parents(subtraction_JSON_obj["parents"]);
-            if (!rp.first) {
-                if (err_msg) {
-                    std::string int_err = rp.second;
-                    std::string ext_err = "Failed on call to lot.remove_parents: ";
-                    *err_msg = strdup((ext_err + int_err).c_str());
-                }
-            return -1; 
+        rp = lot.remove_parents(subtraction_JSON_obj["parents"]);
+        if (!rp.first) {
+            if (err_msg) {
+                std::string int_err = rp.second;
+                std::string ext_err = "Failed on call to lot.remove_parents: ";
+                *err_msg = strdup((ext_err + int_err).c_str());
             }
+        return -1; 
         }
 
-        // Operate on paths key
-        if (subtraction_JSON_obj.contains("paths")) {
-            rp = lot.remove_paths(subtraction_JSON_obj["paths"]);
-            if (!rp.first) {
-                if (err_msg) {
-                    std::string int_err = rp.second;
-                    std::string ext_err = "Failed on call to lot.remove_paths: ";
-                    *err_msg = strdup((ext_err + int_err).c_str());
-                }
-            return -1; 
-            }
-        }
         return 0;
     }
     catch (std::exception &exc) {
@@ -441,6 +424,71 @@ int lotman_remove_from_lot(const char *lotman_JSON_str, char **err_msg) {
     }
 }
 
+int lotman_rm_paths_from_lots(const char *lotman_JSON_str, char **err_msg) {
+    try {
+         json subtraction_JSON_obj = json::parse(lotman_JSON_str);
+        // Validate the incoming JSON
+        json_validator validator;
+        validator.set_root_schema(lotman_schemas::lot_rm_paths_schema);
+        validator.validate(subtraction_JSON_obj);
+
+        // For each path, figure out which lot it belongs to
+        // Knowing the lot name is required for context checking
+        for (const auto &path : subtraction_JSON_obj["paths"]) {
+            std::string path_str{path.get<std::string>()};
+            char *lot_name;
+
+            // If this func hits an error, no need to free lot_name because it
+            // shouldn't make it to strdup
+            int rv = lotman_get_lot_from_dir(path_str.c_str(), &lot_name, err_msg);
+            if (rv != 0) {
+                // An error message will already be populated to err_msg
+                return -1;
+            }
+
+            if (!lot_name) { // When no lot is found, lot_name is set to nullptr
+                // There's nothing to remove, so jump to next path
+                continue;
+            }
+
+            // Initialize the lot
+            lotman::Lot lot(lot_name);
+            free(lot_name); // Lot is initialized, don't need this anymore.
+
+            //Check for context
+            lot.get_parents(true, true);
+            auto rp = lot.check_context_for_parents(lot.recursive_parents, true);
+            if (!rp.first) {
+                if (err_msg) {
+                    std::string int_err = rp.second;
+                    std::string ext_err = "Error while checking context for parents: ";
+                    *err_msg = strdup((ext_err + int_err).c_str());
+                }
+                return -1; 
+            }
+
+            std::vector<std::string> plc_hldr_vec{path_str};
+            rp = lot.remove_paths(plc_hldr_vec); // Keeping std::vector<std::string> signature for now, even though it only gets passed one thing at a time
+            if (!rp.first) {
+                if (err_msg) {
+                    std::string int_err = rp.second;
+                    std::string ext_err = "Failed on call to lot.remove_paths: ";
+                    *err_msg = strdup((ext_err + int_err).c_str());
+                }
+            return -1; 
+            }
+        }
+        
+        return 0;
+    }
+    catch (std::exception &exc) {
+        if (err_msg) {
+            *err_msg = strdup(exc.what());
+        }
+        return -1;
+
+    }
+}
 
 int lotman_add_to_lot(const char *lotman_JSON_str, char **err_msg) {
     try {    
@@ -851,6 +899,38 @@ int lotman_get_policy_attributes(const char *policy_attributes_JSON_str,
         auto output_str_c = static_cast<char *>(malloc(sizeof(char) * (output_str.length() + 1)));
         output_str_c = strdup(output_str.c_str());
         *output = output_str_c;
+        return 0;
+    }
+    catch (std::exception &exc) {
+        if (err_msg) {
+            *err_msg = strdup(exc.what());
+        }
+        return -1;
+    }
+}
+
+int lotman_get_lot_from_dir(const char *dir_name, char **output, char **err_msg) {
+    try {
+        auto rp = lotman::Lot::get_lot_from_dir(dir_name);
+        if (!rp.second.empty()) { // There was an error
+            if (err_msg) {
+                    std::string int_err = rp.second;
+                    std::string ext_err = "Failed to get lot name: ";
+                    *err_msg = strdup((ext_err + int_err).c_str());
+                }
+            return -1; 
+        }
+
+        // Sometimes a path might not come from a lot, so we need to check that a lot name was found
+        if (rp.first.empty()) { // No error and no lot --> no lot was found
+            *output = nullptr; // this is how we indicate that no lot was found. 
+            return 0;
+        }
+        // Now safe to copy lot name to output
+        std::string lot_name_str = rp.first;
+        auto lot_name_str_c = static_cast<char *>(malloc(sizeof(char) * (lot_name_str.length() + 1)));
+        lot_name_str_c = strdup(lot_name_str.c_str());
+        *output = lot_name_str_c;
         return 0;
     }
     catch (std::exception &exc) {

--- a/src/lotman.h
+++ b/src/lotman.h
@@ -196,8 +196,8 @@ int lotman_update_lot(const char *lotman_JSON_str, char **err_msg);
 
 
 
-int lotman_remove_from_lot(const char *remove_dirs_JSON_str, char **err_msg);
-
+int lotman_rm_parents_from_lot(const char *remove_dirs_JSON_str, char **err_msg);
+int lotman_rm_paths_from_lots(const char *remove_dirs_JSON_str, char **err_msg);
 
 
 
@@ -222,6 +222,7 @@ int lotman_update_lot_usage_by_dir(const char *update_JSON_str, char **err_msg);
 
 void lotman_free_string_list(char **str_list);
 //int lotman_check_db_health(char **err_msg); // Should eventually check that data structure conforms to expectations. If there's a cycle or a non-self-parent root, something is wrong
+int lotman_get_lot_from_dir(const char *dir_name, char **output, char **err_msg);
 int lotman_get_lots_past_exp(const bool recursive, char ***output, char **err_msg);
 int lotman_get_lots_past_del(const bool recursive, char ***output, char **err_msg);
 int lotman_get_lots_past_opp(const bool recursive_quota, const bool recursive_children, char ***output, char **err_msg);

--- a/src/lotman.h
+++ b/src/lotman.h
@@ -6,35 +6,204 @@
 extern "C" {
 #endif
 
-
-/**
- * API for getting LotMan library version.
+/*
+API Functions
 */
+
 const char * lotman_version();
+/**
+    DESCRIPTION: Returns current version of LotMan
+*/
+
 int lotman_lot_exists(const char *lot_name, char **err_msg);
-
 /**
- * API for creating a "lot."
- * Takes in a JSON lot object as a string and attempts to create the lot as defined by the JSON object.
- * Returns 0 upon success, nonzero for failure.
+    DESCRIPTION: A function for determining whether a lot exists in the lot database. 
+    
+    RETURNS: Returns 0 if the lot does not exist, 1 if the lot does exist. Any other
+        values indicate an error. 
+
+    INPUTS:
+    lot_name:
+        The name of the lot whose existence is to be determine.
+    err_msg:
+        A reference to a char array that can store any error messages. 
+
+    OUTPUTS: An error message, when one is generated.
 */
+
+
 int lotman_add_lot(const char *lotman_JSON_str, char **err_msg);
+/**
+    DESCRIPTION: Function for adding/creating a lot, which gets stored in the lot database. 
+    
+    RETURNS: Returns 0 on success. Any other values indicate an error.
+
+    INPUTS: 
+    lotman_JSON_str: 
+        REQUIRED. A string defining the lot in JSON (see below for lot object specification)
+    
+    err_msg:
+        REQUIRED. A reference to a char array that can store any error messages.
+    
+    OUTPUTS: An error message, when one is generated. 
+
+    Lot Object specification:
+    
+{   "lot_name": 
+        REQUIRED. A string indicating the name of the lot. 
+    "owner": 
+        REQUIRED. A string indicating the entity that "owns" the contents of the lot. Ownership of a lot
+        indicates ownership of the lots contents, but not the lot itself; like renting a garden -- 
+        you own what you grow, but not the dirt you grow it in. A lot owner cannot modify the lot's
+        properties unless the lot is a self parent. However, the owner can modify the properties of
+        any sub lots. 
+    "parents": 
+        REQUIRED. An array of strings indicating any lots that are parent to the lot about to be added.
+        Any parents specified must already exist in the lot database, unless the specified parent
+        is the lot itself. At least one parent must be specified.
+    "children": 
+        OPTIONAL. An array of strings indicating any lots that are children of the lot about to be added.
+        Any children must already exist in the lot database. A lot should not specify itself as
+        a child, as this case is already handled by the self parent mechanism.
+    "paths": 
+        OPTIONAL. An array of `path` objects that are used to associate paths/objects to the lot. Each 
+        path object has the following structure:
+        {"path": "/path/to/associate", "recursive": bool}
+        When "recursive" is true, all subdirectories of the path are also attributed to the lot. When false,
+        only non-directory objects below the path should be attributed, but any subdirectories should not be.
+    "management_policy_attrs": 
+        REQUIRED. A JSON object containing the collection of attributes used for creating policies for the 
+        lot. The object has the following structure:
+
+    {   "dedicated_GB":
+            REQUIRED. A double indicating the size in GB of dedicated storage a lot possesses. During a lot's 
+            lifespan, this is the amount of persistant storage it should be allowed to access.
+        "opportunistic_GB":
+            REQUIRED. A double indicating the size in GB of opportunistic storage a lot possesses. During a 
+            lot's lifespan, this is the amount of extra storage it should be able to access after all 
+            dedicated storage has been exhausted if the system determines there is unused capacity. Opp 
+            storage should be considered transient, and as such, depending on the management policy, lots 
+            that are using some amount of opp storage may be subject to purging in the event that the system 
+            needs to create space.
+        "max_num_objects": An int64 indicating the maxiximum number of objects a lot may have attributed to it.
+        "creation_time":
+            REQUIRED. A Unix timestamp in milliseconds indicating when the lot should begin its existence.
+        "expiration_time":
+            REQUIRED. A Unix timestamp in milliseconds indicating when the lot "expires". In a similar vein
+            as opp storage, a lot and its storage become transient after its expiration time has passed. If 
+            the system determines there is unused space, the lot may continue to exist, but all storage tied 
+            to the lot should be considered opportunistic.
+        "deletion_time":
+            REQUIRED. A Unix timestamp in milliseconds indicating when the lot and its contents should be deleted.
+    }
+}
+*/
+
+int lotman_remove_lot(const char *lot_name, bool assign_LTBR_parent_as_parent_to_orphans,
+                      bool assign_LTBR_parent_as_parent_to_non_orphans, bool assign_policy_to_children, 
+                      const bool override_policy, char **err_msg);
+/**
+    DESCRIPTION: Function for deleting a lot, but preserving any children lots. In general, the function to remove
+        lots recursively should be favored over this function. When this func is used, LotMan will attempt to handle 
+        the proper policy/parent reassignments for children lots according to the selection of options. These 
+        reassignments are necessary to preseve the lot database's structure.
+        NOTE: Deleting a lot does not actually affect the objects tied to the lot. It only removes the lot from the
+            lot database. 
+
+    RETURNS: Returns 0 on success. Any other values indicate an error.
+
+    INPUTS: 
+    lot_name: 
+        A string indicating the name of the lot to be removed (LTBR)
+    
+    assign_LTBR_parent_as_parent_to_orphans:
+        A bool indicating whether LotMan should attempt to assign LTBR's parents as the new parents to any lots 
+        orphaned by LTBR's removal. If true, any lots whose only parent is currently LTBR will be reassigned to 
+        have LTBR's parents as explicit parents. If false, any orphans will automatically be reassigned to have 
+        the default lot as a parent.
+        NOTE: If LTBR is a root (ie it has only itself as a parent) and this option is true, the function should 
+            fail with an indication that the child could not be reassigned because LTBR has no parents. This is 
+            to explicity ensure the user is aware the orphans must be reassigned to the default lot.
+    
+    assign_LTBR_parent_as_parent_to_non_orphans:
+        A bool indicating whether LotMan should attempt to assign LTBR's parents as the new parents to any lots
+        that are not orphaned by LTBR's removal. If true, any non-orphans will be updated to have LTBR's parents 
+        as explicit parents. If false, LTBR will be removed as a parent from the non-orphaned children and no extra 
+        parents will be added. 
+        NOTE: If a child of LTBR has only LTBR and itself as a parent, setting this option to false will cause that 
+            child to become a root.
+        NOTE: If LTBR is a root and this option is true, the function should fail with an indication that the child 
+            could not be reassigned because LTBR has no parents.
+
+    assign_policy_to_children:
+        A bool indicating whether LTBR's management policy attributes should be assigned to its children. If true,
+        LTBR's children will have their policy attributes overwritten by LTBR's.
+
+    override_policy:
+        THIS FEATURE IS NOT YET IMPLEMENTED. A bool indicating whether a lot's stored deletion policy should be 
+        overwritten by the other options. If true, the lot will be deleted according to other options. If false,
+        any of the other options will be superceded by the stored deletion policy 
+
+    err_msg:
+        REQUIRED. A reference to a char array that can store any error messages.
+    
+    OUTPUTS: An error message, when one is generated.
+*/
+
+
+
+
+
+
+
+
 
 /**
- * API for deleting a lot. LTBR = lot-to-be-removed.
- * OPTION assign_LTBR_parent_as_parent_to_orphans: If true, any lots whose only parent is currently LTBR will be reassigned to have LTBR's parents as explicit parents.
- *         If false, any orphans will automatically be reassigned to have the default lot as a parent.
- *         NOTE: If LTBR is a root (ie it has only itself as a parent) and this option is true, the function should fail with an indication that the child could not be 
- *               reassigned because LTBR has no parents. This is to explicity ensure the user is aware the orphans must be reassigned to the default lot.
- * OPTION assign_LTBR_parent_as_parent_to_non_orphans: If true, any non-orphans will be updated to have LTBR's parents as explicit parents. If false, LTBR will be removed as 
- *         a parent from the non-orphaned children and no extra parents will be added. 
- *         NOTE: If a child of LTBR has only LTBR and itself as a parent, setting this option to false will cause that child to become a root.
- *         NOTE: If LTBR is a root and this option is true, the function should fail with an indication that the child could not be reassigned because LTBR has no parents.
- * OPTION assign_policy_to_children: If true, the policy attributes of all of LTBR's children will be overwritten with LTBR's policy attributes.
+    DESCRIPTION: 
+
+    RETURNS:
+
+    INPUTS: 
+    
+    
+    OUTPUTS: An error message, when one is generated.
+
 */
-int lotman_remove_lot(const char *lot_name, bool assign_LTBR_parent_as_parent_to_orphans, bool assign_LTBR_parent_as_parent_to_non_orphans, bool assign_policy_to_children, const bool override_policy, char **err_msg);
+
+
+
+
+
+
+
+
 int lotman_remove_lots_recursive(const char *lot_name, char **err_msg);
+/**
+    DESCRIPTION: A function for deleting a lot and its children, recursively. 
+
+    RETURNS:
+
+    INPUTS: 
+    
+    
+    OUTPUTS: An error message, when one is generated.
+
+*/
 int lotman_update_lot(const char *lotman_JSON_str, char **err_msg);
+
+
+
+
+
+
+int lotman_remove_from_lot(const char *remove_dirs_JSON_str, char **err_msg);
+
+
+
+
+
+
+
 int lotman_add_to_lot(const char *lotman_JSON_str, char **err_msg);
 
 

--- a/src/lotman_db.cpp
+++ b/src/lotman_db.cpp
@@ -421,6 +421,7 @@ std::pair<bool, std::string> lotman::Lot::delete_lot_from_db() {
         sqlite3_close(db);
         return std::make_pair(false, "Failed to delete lot from owners table: sqlite3 errno: " + std::to_string(rc));
     }
+    sqlite3_finalize(stmt);
     sqlite3_exec(db, "COMMIT", 0, 0, 0);
     
     // Delete from parents table
@@ -440,6 +441,7 @@ std::pair<bool, std::string> lotman::Lot::delete_lot_from_db() {
         sqlite3_close(db);
         return std::make_pair(false, "Failed to delete lot from parents table: sqlite3 errno: " + std::to_string(rc));
     }
+    sqlite3_finalize(stmt);
     sqlite3_exec(db, "COMMIT", 0, 0, 0);
 
     // Delete from paths
@@ -459,6 +461,7 @@ std::pair<bool, std::string> lotman::Lot::delete_lot_from_db() {
         sqlite3_close(db);
         return std::make_pair(false, "Failed to delete lot from paths table: sqlite3 errno: " + std::to_string(rc));
     }
+    sqlite3_finalize(stmt);
     sqlite3_exec(db, "COMMIT", 0, 0, 0);
 
     // Delete from management_policy_attributes
@@ -478,6 +481,7 @@ std::pair<bool, std::string> lotman::Lot::delete_lot_from_db() {
         sqlite3_close(db);
         return std::make_pair(false, "Failed to delete lot from management_policy_attributes table: sqlite3 errno: " + std::to_string(rc));
     }
+    sqlite3_finalize(stmt);
     sqlite3_exec(db, "COMMIT", 0, 0, 0);
 
     // Delete from lot_usage
@@ -497,9 +501,9 @@ std::pair<bool, std::string> lotman::Lot::delete_lot_from_db() {
         sqlite3_close(db);
         return std::make_pair(false, "Failed to delete lot from usage table: sqlite3 errno: " + std::to_string(rc));
     }
-    sqlite3_exec(db, "COMMIT", 0, 0, 0);
 
     sqlite3_finalize(stmt);
+    sqlite3_exec(db, "COMMIT", 0, 0, 0);
     sqlite3_close(db);
 
     return std::make_pair(true, "");

--- a/src/lotman_db.cpp
+++ b/src/lotman_db.cpp
@@ -3,6 +3,7 @@
 #include <sqlite3.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <iostream>
 
 #include "lotman_internal.h"
 
@@ -667,6 +668,102 @@ std::pair<bool, std::string> lotman::Lot::store_new_parents(std::vector<Lot> new
     sqlite3_close(db);
 
     return std::make_pair(true, "");    
+}
+
+std::pair<bool, std::string> lotman::Lot::remove_parents_from_db( std::vector<std::string> parents) {
+    auto lot_fname = get_lot_file();
+    if (!lot_fname.first) {
+        return std::make_pair(false, "Could not get lot_file: " + lot_fname.second);
+    }
+    sqlite3 *db;
+    int rc = sqlite3_open(lot_fname.second.c_str(), &db);
+    if (rc) {
+        sqlite3_close(db);
+        return std::make_pair(false, "Unable to open lotdb: sqlite errno: " + std::to_string(rc));
+    }
+
+    // Delete from parents table
+    for (const auto &parent : parents) {
+        sqlite3_stmt *stmt;
+        rc = sqlite3_prepare_v2(db, "DELETE FROM parents WHERE lot_name = ? AND parent = ?;", -1, &stmt, NULL);
+        if (rc != SQLITE_OK) {
+            sqlite3_close(db);
+            return std::make_pair(false, "Call to sqlite3_prepare_v2 failed when preparing statement to delete parents from the lot: sqlite3 errno: " + std::to_string(rc));
+        }
+
+        // Bind the lot
+        if (sqlite3_bind_text(stmt, 1, lot_name.c_str(), lot_name.size(), SQLITE_TRANSIENT) != SQLITE_OK) {
+            sqlite3_finalize(stmt);
+            sqlite3_close(db);
+            return std::make_pair(false, "Call to sqlite3_bind_text for lot_name failed when preparing to delete a parent from parents table: sqlite errno: " + std::to_string(rc));
+        }
+
+        // Bind the parent
+        if (sqlite3_bind_text(stmt, 2, parent.c_str(), parent.size(), SQLITE_TRANSIENT) != SQLITE_OK) {
+            sqlite3_finalize(stmt);
+            sqlite3_close(db);
+            return std::make_pair(false, "Call to sqlite3_bind_text for parent.lot_name failed when preparing to delete a parent from parents table: sqlite errno: " + std::to_string(rc));
+        }
+        rc = sqlite3_step(stmt);
+        if (rc != SQLITE_DONE) {
+            sqlite3_finalize(stmt);
+            sqlite3_close(db);
+            return std::make_pair(false, "Failed to delete parent from parents table: sqlite3 errno: " + std::to_string(rc));
+        }
+        sqlite3_exec(db, "COMMIT", 0, 0, 0);
+        sqlite3_finalize(stmt); 
+    }
+
+    sqlite3_close(db);
+    return std::make_pair(true, "");
+}
+
+std::pair<bool, std::string> lotman::Lot::remove_paths_from_db(std::vector<std::string> paths) {
+    auto lot_fname = get_lot_file();
+    if (!lot_fname.first) {
+        return std::make_pair(false, "Could not get lot_file: " + lot_fname.second);
+    }
+    sqlite3 *db;
+    int rc = sqlite3_open(lot_fname.second.c_str(), &db);
+    if (rc) {
+        sqlite3_close(db);
+        return std::make_pair(false, "Unable to open lotdb: sqlite errno: " + std::to_string(rc));
+    }
+
+    // Delete from paths table
+    for (const auto &path : paths) {
+        sqlite3_stmt *stmt;
+        rc = sqlite3_prepare_v2(db, "DELETE FROM paths WHERE lot_name = ? AND path = ?;", -1, &stmt, NULL);
+        if (rc != SQLITE_OK) {
+            sqlite3_close(db);
+            return std::make_pair(false, "Call to sqlite3_prepare_v2 failed when preparing statement to delete paths from the lot: sqlite3 errno: " + std::to_string(rc));
+        }
+
+        // Bind the lot
+        if (sqlite3_bind_text(stmt, 1, lot_name.c_str(), lot_name.size(), SQLITE_TRANSIENT) != SQLITE_OK) {
+            sqlite3_finalize(stmt);
+            sqlite3_close(db);
+            return std::make_pair(false, "Call to sqlite3_bind_text for lot_name failed when preparing to delete a path from paths table: sqlite errno: " + std::to_string(rc));
+        }
+
+        // Bind the path
+        if (sqlite3_bind_text(stmt, 2, path.c_str(), path.size(), SQLITE_TRANSIENT) != SQLITE_OK) {
+            sqlite3_finalize(stmt);
+            sqlite3_close(db);
+            return std::make_pair(false, "Call to sqlite3_bind_text for path failed when preparing to delete a path from paths table: sqlite errno: " + std::to_string(rc));
+        }
+        rc = sqlite3_step(stmt);
+        if (rc != SQLITE_DONE) {
+            sqlite3_finalize(stmt);
+            sqlite3_close(db);
+            return std::make_pair(false, "Failed to delete path from path table: sqlite3 errno: " + std::to_string(rc));
+        }
+        sqlite3_exec(db, "COMMIT", 0, 0, 0);
+        sqlite3_finalize(stmt); 
+    }
+
+    sqlite3_close(db);
+    return std::make_pair(true, "");
 }
 
 std::pair<std::vector<std::string>, std::string> lotman::Checks::SQL_get_matches(std::string dynamic_query, std::map<std::string, std::vector<int>> str_map, std::map<int64_t, std::vector<int>> int_map, std::map<double, std::vector<int>> double_map) { 

--- a/src/lotman_db.cpp
+++ b/src/lotman_db.cpp
@@ -3,7 +3,6 @@
 #include <sqlite3.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <iostream>
 
 #include "lotman_internal.h"
 
@@ -733,21 +732,22 @@ std::pair<bool, std::string> lotman::Lot::remove_paths_from_db(std::vector<std::
     // Delete from paths table
     for (const auto &path : paths) {
         sqlite3_stmt *stmt;
-        rc = sqlite3_prepare_v2(db, "DELETE FROM paths WHERE lot_name = ? AND path = ?;", -1, &stmt, NULL);
+        // rc = sqlite3_prepare_v2(db, "DELETE FROM paths WHERE lot_name = ? AND path = ?;", -1, &stmt, NULL);
+        rc = sqlite3_prepare_v2(db, "DELETE FROM paths WHERE path = ?;", -1, &stmt, NULL); // Because paths should be unique, we don't need to specify which lot
         if (rc != SQLITE_OK) {
             sqlite3_close(db);
             return std::make_pair(false, "Call to sqlite3_prepare_v2 failed when preparing statement to delete paths from the lot: sqlite3 errno: " + std::to_string(rc));
         }
 
-        // Bind the lot
-        if (sqlite3_bind_text(stmt, 1, lot_name.c_str(), lot_name.size(), SQLITE_TRANSIENT) != SQLITE_OK) {
-            sqlite3_finalize(stmt);
-            sqlite3_close(db);
-            return std::make_pair(false, "Call to sqlite3_bind_text for lot_name failed when preparing to delete a path from paths table: sqlite errno: " + std::to_string(rc));
-        }
+        // // Bind the lot
+        // if (sqlite3_bind_text(stmt, 1, lot_name.c_str(), lot_name.size(), SQLITE_TRANSIENT) != SQLITE_OK) {
+        //     sqlite3_finalize(stmt);
+        //     sqlite3_close(db);
+        //     return std::make_pair(false, "Call to sqlite3_bind_text for lot_name failed when preparing to delete a path from paths table: sqlite errno: " + std::to_string(rc));
+        // }
 
         // Bind the path
-        if (sqlite3_bind_text(stmt, 2, path.c_str(), path.size(), SQLITE_TRANSIENT) != SQLITE_OK) {
+        if (sqlite3_bind_text(stmt, 1, path.c_str(), path.size(), SQLITE_TRANSIENT) != SQLITE_OK) {
             sqlite3_finalize(stmt);
             sqlite3_close(db);
             return std::make_pair(false, "Call to sqlite3_bind_text for path failed when preparing to delete a path from paths table: sqlite errno: " + std::to_string(rc));

--- a/src/lotman_internal.cpp
+++ b/src/lotman_internal.cpp
@@ -2,8 +2,6 @@
 #include <nlohmann/json.hpp>
 #include <sqlite3.h>
 
-#include <iostream>
-
 #include "lotman_internal.h"
 
 using json = nlohmann::json;
@@ -659,6 +657,30 @@ std::pair<json, std::string> lotman::Lot::get_lot_dirs(const bool recursive) {
     catch (std::exception &exc) {
         return std::make_pair(json(), exc.what());
     }
+}
+
+std::pair<std::string, std::string> lotman::Lot::get_lot_from_dir(const std::string dir_path) {
+    try {
+        std::string lot_name_query = "SELECT lot_name FROM paths WHERE path = ?;";
+        std::map<std::string, std::vector<int>> query_map{{dir_path, {1}}};
+        auto rp = lotman::Checks::SQL_get_matches(lot_name_query, query_map);
+        if (!rp.second.empty()) { // There was an error
+            std::string int_err = rp.second;
+            std::string ext_err = "Failure on call to SQL_get_matches: ";
+            return std::make_pair("", ext_err + int_err);
+        }
+
+        // rp.first[0] now contains the name of the lot, if one existed
+        if (rp.first.empty()) {
+            return std::make_pair("", ""); // Nothing existed, and no error. Return empty strings!
+        }
+        return std::make_pair(rp.first[0], "");
+    }
+    catch (std::exception &exc) {
+        return std::make_pair("", exc.what());
+    }
+
+
 }
 
 std::pair<json, std::string> lotman::Lot::get_lot_usage(const std::string key, const bool recursive) {

--- a/src/lotman_internal.h
+++ b/src/lotman_internal.h
@@ -105,6 +105,7 @@ class Lot {
                                                                const bool recursive);
 
         std::pair<json, std::string> get_lot_dirs(const bool recursive);
+        static std::pair<std::string, std::string> get_lot_from_dir(const std::string dir_path);
 
         std::pair<json, std::string> get_lot_usage(const std::string key,
                                                    const bool recursive);
@@ -112,16 +113,8 @@ class Lot {
         std::pair<bool, std::string> add_parents(std::vector<Lot> parents);
         std::pair<bool, std::string> add_paths(std::vector<json> paths);
 
-
-
-
-
         std::pair<bool, std::string> remove_parents(std::vector<std::string> parents);
         std::pair<bool, std::string> remove_paths(std::vector<std::string> paths);
-
-
-
-
 
         std::pair<bool, std::string> update_owner(std::string update_val);
         std::pair<bool, std::string> update_parents(json update_arr);
@@ -146,9 +139,6 @@ class Lot {
         static std::pair<std::vector<std::string>, std::string> get_lots_past_obj(const bool recursive_quota, const bool recursive_children);
         static std::pair<std::vector<std::string>, std::string> list_all_lots();
         static std::pair<std::vector<std::string>, std::string> get_lots_from_dir(std::string dir, const bool recursive);
-        
-
-
 
     private:
         std::pair<bool, std::string> write_new();
@@ -163,7 +153,6 @@ class Lot {
         std::pair<bool, std::string> remove_paths_from_db(std::vector<std::string> paths);
 
 };
-
 
 class DirUsageUpdate : public Lot {
 public: 

--- a/src/lotman_internal.h
+++ b/src/lotman_internal.h
@@ -70,20 +70,17 @@ class Lot {
             bool assign_policy_to_children;
         } reassignment_policy;
 
+        // Should re-evaluate whether all/any of these are needed...
         bool full_lot = false;
         bool has_name = false;
         bool has_reassignment_policy = false;
         bool is_root;
         
-
-
         // Constructors
         Lot() {};
         Lot(const char * lot_name) : lot_name{lot_name}, has_name{true} {};
         Lot(std::string lot_name) : lot_name{lot_name}, has_name{true} {};
         Lot(json lot_JSON) {init_full(lot_JSON);};
-
-
 
         std::pair<bool, std::string> init_full(json lot_JSON); 
         std::pair<bool, std::string> init_reassignment_policy(const bool assign_LTBR_parent_as_parent_to_orphans, 
@@ -114,6 +111,17 @@ class Lot {
 
         std::pair<bool, std::string> add_parents(std::vector<Lot> parents);
         std::pair<bool, std::string> add_paths(std::vector<json> paths);
+
+
+
+
+
+        std::pair<bool, std::string> remove_parents(std::vector<std::string> parents);
+        std::pair<bool, std::string> remove_paths(std::vector<std::string> paths);
+
+
+
+
 
         std::pair<bool, std::string> update_owner(std::string update_val);
         std::pair<bool, std::string> update_parents(json update_arr);
@@ -151,6 +159,8 @@ class Lot {
                                                    std::map<std::string, std::vector<int>> update_str_map = std::map<std::string, std::vector<int>>(),
                                                    std::map<int64_t, std::vector<int>> update_int_map =std::map<int64_t, std::vector<int>>(),
                                                    std::map<double, std::vector<int>> update_dbl_map = std::map<double, std::vector<int>>());
+        std::pair<bool, std::string> remove_parents_from_db(std::vector<std::string> parents);
+        std::pair<bool, std::string> remove_paths_from_db(std::vector<std::string> paths);
 
 };
 

--- a/src/schemas.h
+++ b/src/schemas.h
@@ -211,6 +211,41 @@ json lot_update_schema = R"(
 }
 )"_json;
 
+json lot_subtractions_schema = R"(
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "title": "subtraction obj",
+    "additionalProperties": false,
+    "properties": {
+        "lot_name": {
+            "description": "Name of lot being modified",
+            "type": "string",
+            "minLength": 1
+        },
+
+        "parents": {
+            "description": "The names of parent lots to be removed",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems":1
+        },
+        
+        "paths": {
+            "description": "The paths to be removed from the lot",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems":1
+        }
+    },
+    "required": ["lot_name"]
+}
+)"_json;
+
 json lot_additions_schema = R"(
 {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas.h
+++ b/src/schemas.h
@@ -211,7 +211,7 @@ json lot_update_schema = R"(
 }
 )"_json;
 
-json lot_subtractions_schema = R"(
+json lot_rm_parents_schema = R"(
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -231,8 +231,19 @@ json lot_subtractions_schema = R"(
                 "type": "string"
             },
             "minItems":1
-        },
-        
+        }
+    },
+    "required": ["lot_name", "parents"]
+}
+)"_json;
+
+json lot_rm_paths_schema = R"(
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "title": "subtraction obj",
+    "additionalProperties": false,
+    "properties": {
         "paths": {
             "description": "The paths to be removed from the lot",
             "type": "array",
@@ -242,7 +253,7 @@ json lot_subtractions_schema = R"(
             "minItems":1
         }
     },
-    "required": ["lot_name"]
+    "required": ["paths"]
 }
 )"_json;
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -133,8 +133,9 @@ namespace {
         rv = lotman_update_lot(modified_lot2, &err_msg);
         ASSERT_FALSE(rv == 0);
 
+        char *err_msg2;
         char **owner_out;
-        rv = lotman_get_owners("lot3", false, &owner_out, &err_msg);
+        rv = lotman_get_owners("lot3", false, &owner_out, &err_msg2);
         ASSERT_TRUE(rv == 0) << err_msg;
         
         bool check_old = false, check_new =  false;
@@ -150,7 +151,7 @@ namespace {
         lotman_free_string_list(owner_out);
 
         char **parents_out;
-        rv = lotman_get_parent_names("lot3", false, true, &parents_out, &err_msg);
+        rv = lotman_get_parent_names("lot3", false, true, &parents_out, &err_msg2);
         ASSERT_TRUE(rv == 0) << err_msg;
 
         check_old = false, check_new = false;
@@ -171,8 +172,25 @@ namespace {
 
         // Try to add a cycle --> this should fail
         const char *addition_JSON2 = "{ \"lot_name\": \"lot1\", \"parents\": [\"lot2\"]}";
-        rv = lotman_add_to_lot(addition_JSON2, &err_msg);
+        rv = lotman_add_to_lot(addition_JSON2, &err_msg2);
         ASSERT_FALSE(rv == 0);
+
+        // Test removing parents/paths from lots
+        // Add default as parent to sep_node, then remove
+        char *err_msg3;
+        const char *addition_JSON3 = "{\"lot_name\":\"sep_node\", \"paths\":[{\"path\":\"/here/is/a/path\", \"recursive\": true}], \"parents\": [\"default\"]}";
+        rv = lotman_add_to_lot(addition_JSON3, &err_msg3);
+        ASSERT_TRUE(rv == 0) << err_msg;
+
+        // Try (and hopefully fail) to remove all of the parents and orphan the lot
+        const char *removal_JSON1 = "{\"lot_name\":\"sep_node\", \"parents\":[\"default\", \"sep_node\", \"non_existent_parent\"]}";
+        rv = lotman_remove_from_lot(removal_JSON1, &err_msg3);
+        ASSERT_FALSE(rv == 0);
+
+        char *err_msg4;
+        const char *removal_JSON2 = "{\"lot_name\":\"sep_node\", \"paths\":[\"/here/is/a/path\"], \"parents\":[\"default\"]}";
+        rv = lotman_remove_from_lot(removal_JSON2, &err_msg4);
+        ASSERT_TRUE(rv == 0) << err_msg;
     }
 
     TEST(LotManTest, SetGetUsageTest) {


### PR DESCRIPTION
I somehow forgot to include an API that can remove select files/parents from a lot! Previously, the only way to do this was to delete the entire lot, which wasn't so great.